### PR TITLE
AR-9-2-3_Crear_PUT_Delete_de_la_comision

### DIFF
--- a/usArt_backend/catalog/serializers.py
+++ b/usArt_backend/catalog/serializers.py
@@ -22,3 +22,4 @@ class CommissionListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Commission
         fields = '__all__'
+        extra_kwargs = {'description': {'required': False}}

--- a/usArt_backend/catalog/tests.py
+++ b/usArt_backend/catalog/tests.py
@@ -121,14 +121,12 @@ class TestPublicationAPI(APITestCase):
         user = UsArtUser.objects.get(user_name='test')
         pub = Publication.objects.get(title='Title test 3')
         update_data = {
-            'user_id': user.id,
-            'pub_id': pub.id,
-            'description': None,
             'status': 'AC'
         }
-        url = reverse('catalog:commission_update_delete')
+        url = reverse('catalog:commission_update_delete', kwargs={'pub_id': pub.id, 'user_id': user.id})
         response = self.client.put(url, update_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
         url_post_login = reverse('api:token_obtain_pair')
         login_data = {
             'user_name': 'test2',
@@ -139,61 +137,41 @@ class TestPublicationAPI(APITestCase):
         self.assertTrue('access' in response.data)
         token = response.data['access']
         self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(token))
-        user = UsArtUser.objects.get(user_name='test')
-        pub = Publication.objects.get(title='Title test 3')
+
         update_data = {
-            'user_id': user.id,
-            'pub_id': pub.id,
-            'description': None,
             'status': 'AC'
         }
-        url = reverse('catalog:commission_update_delete')
         response = self.client.put(url, update_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'AC')
 
         update_data2 = {
-            'user_id': user.id,
-            'pub_id': pub.id,
             'description': 'Description Changed',
             'status': 'DO'
         }
-        url = reverse('catalog:commission_update_delete')
         response = self.client.put(url, update_data2, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['description'], 'Description Changed')
         self.assertEqual(response.data['status'], 'DO')
 
         update_data3 = {
-            'user_id': user.id,
-            'pub_id': pub.id,
             'description': 'Description Changed',
-            'status': None
         }
-        url = reverse('catalog:commission_update_delete')
         response = self.client.put(url, update_data3, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['description'], 'Description Changed')
 
         update_data4 = {
-            'user_id': user.id,
-            'pub_id': pub.id,
-            'description': None,
-            'status': None
+            'description': '',
         }
-        url = reverse('catalog:commission_update_delete')
         response = self.client.put(url, update_data4, format='json')
-        self.assertEqual(response.status_code, status.HTTP_304_NOT_MODIFIED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_commission_delete(self):
         user = UsArtUser.objects.get(user_name='test')
         pub = Publication.objects.get(title='Title test 3')
-        update_data = {
-            'user_id': user.id,
-            'pub_id': pub.id,
-        }
-        url = reverse('catalog:commission_update_delete')
-        response = self.client.put(url, update_data, format='json')
+        url = reverse('catalog:commission_update_delete', kwargs={'pub_id': pub.id, 'user_id': user.id})
+        response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         url_post_login = reverse('api:token_obtain_pair')
         login_data = {
@@ -205,12 +183,5 @@ class TestPublicationAPI(APITestCase):
         self.assertTrue('access' in response.data)
         token = response.data['access']
         self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(token))
-        user = UsArtUser.objects.get(user_name='test')
-        pub = Publication.objects.get(title='Title test 3')
-        update_data = {
-            'user_id': user.id,
-            'pub_id': pub.id
-        }
-        url = reverse('catalog:commission_update_delete')
-        response = self.client.delete(url, update_data, format='json')
+        response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/usArt_backend/catalog/tests.py
+++ b/usArt_backend/catalog/tests.py
@@ -41,7 +41,7 @@ class TestPublicationAPI(APITestCase):
                                    type='CO')
         pub1 = Publication.objects.create(title='Title test 3', description='Description test 3',
                                           author=user2, price=5.0)
-        pub2 = Publication.objects.create(title='Title test 4', description='Description test 4',
+        Publication.objects.create(title='Title test 4', description='Description test 4',
                                           author=user2, price=5.0, type='AU')
         Commission.objects.create(pub_id=pub1, user_id=user, description='Description test user')
         Commission.objects.create(pub_id=pub1, user_id=user3, description='Description test user3')
@@ -116,3 +116,101 @@ class TestPublicationAPI(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
+
+    def test_commission_update(self):
+        user = UsArtUser.objects.get(user_name='test')
+        pub = Publication.objects.get(title='Title test 3')
+        update_data = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+            'description': None,
+            'status': 'AC'
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        url_post_login = reverse('api:token_obtain_pair')
+        login_data = {
+            'user_name': 'test2',
+            'password': 'test'
+        }
+        response = self.client.post(url_post_login, login_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue('access' in response.data)
+        token = response.data['access']
+        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(token))
+        user = UsArtUser.objects.get(user_name='test')
+        pub = Publication.objects.get(title='Title test 3')
+        update_data = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+            'description': None,
+            'status': 'AC'
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'AC')
+
+        update_data2 = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+            'description': 'Description Changed',
+            'status': 'DO'
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data2, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['description'], 'Description Changed')
+        self.assertEqual(response.data['status'], 'DO')
+
+        update_data3 = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+            'description': 'Description Changed',
+            'status': None
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data3, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['description'], 'Description Changed')
+
+        update_data4 = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+            'description': None,
+            'status': None
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data4, format='json')
+        self.assertEqual(response.status_code, status.HTTP_304_NOT_MODIFIED)
+
+    def test_commission_delete(self):
+        user = UsArtUser.objects.get(user_name='test')
+        pub = Publication.objects.get(title='Title test 3')
+        update_data = {
+            'user_id': user.id,
+            'pub_id': pub.id,
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.put(url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        url_post_login = reverse('api:token_obtain_pair')
+        login_data = {
+            'user_name': 'test2',
+            'password': 'test'
+        }
+        response = self.client.post(url_post_login, login_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue('access' in response.data)
+        token = response.data['access']
+        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(token))
+        user = UsArtUser.objects.get(user_name='test')
+        pub = Publication.objects.get(title='Title test 3')
+        update_data = {
+            'user_id': user.id,
+            'pub_id': pub.id
+        }
+        url = reverse('catalog:commission_update_delete')
+        response = self.client.delete(url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/usArt_backend/catalog/urls.py
+++ b/usArt_backend/catalog/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('', views.PublicationList.as_view(), name='publications_list'),
     path('<str:pk>', views.PublicationDetail.as_view(), name='publication_details'),
     path('user/<str:username>', views.PublicationUser.as_view(), name='publications_user'),
-    path('user/comissions/<str:pub_id>', views.CommissionList.as_view(), name='commissions_user'),
+    path('user/commissions/<str:pub_id>', views.CommissionList.as_view(), name='commissions_user'),
+    path('user/commission/', views.CommissionAcceptDelete.as_view(), name='commission_update_delete')
 ]

--- a/usArt_backend/catalog/urls.py
+++ b/usArt_backend/catalog/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path('<str:pk>', views.PublicationDetail.as_view(), name='publication_details'),
     path('user/<str:username>', views.PublicationUser.as_view(), name='publications_user'),
     path('user/commissions/<str:pub_id>', views.CommissionList.as_view(), name='commissions_user'),
-    path('user/commission/', views.CommissionAcceptDelete.as_view(), name='commission_update_delete')
+    path('user/commission/<str:pub_id>&<str:user_id>', views.CommissionAcceptDelete.as_view(),
+         name='commission_update_delete')
 ]

--- a/usArt_backend/catalog/views.py
+++ b/usArt_backend/catalog/views.py
@@ -2,6 +2,15 @@ from catalog.models import Publication, Commission
 from catalog.serializers import PublicationListSerializer, CommissionListSerializer
 
 from rest_framework import filters, generics
+
+from authentication.models import UsArtUser
+from rest_framework.permissions import IsAuthenticated
+from django.shortcuts import get_object_or_404
+from rest_framework.response import Response
+from rest_framework import status
+
+
+
 import django_filters.rest_framework
 
 
@@ -34,3 +43,50 @@ class CommissionList(generics.ListAPIView):
         pub_id = self.kwargs['pub_id']
         commissions = Commission.objects.filter(pub_id__author=self.request.user, pub_id__id=pub_id)
         return commissions
+
+
+class CommissionAcceptDelete(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Commission.objects.all()
+    serializer_class = CommissionListSerializer
+    permission_classes = [IsAuthenticated]
+
+    def put(self, request):
+        user = get_object_or_404(UsArtUser, id=self.request.data['user_id'])
+        pub = get_object_or_404(Publication, id=self.request.data['pub_id'])
+        commission = Commission.objects.get(pub_id__id=self.request.data['pub_id'],
+                                            user_id__id=self.request.data['user_id'])
+        if not request.data['description'] and request.data['status']:
+            data = {
+                'user_id': request.data['user_id'],
+                'pub_id': request.data['pub_id'],
+                'description': commission.description,
+                'status': request.data['status']
+            }
+        elif request.data['description'] and not request.data['status']:
+            data = {
+                'user_id': request.data['user_id'],
+                'pub_id': request.data['pub_id'],
+                'description': request.data['description'],
+                'status': commission.status
+            }
+        elif request.data['description'] and request.data['status']:
+            data = {
+                'user_id': request.data['user_id'],
+                'pub_id': request.data['pub_id'],
+                'description': request.data['description'],
+                'status': request.data['status']
+            }
+        else:
+            return Response(request.data, status.HTTP_304_NOT_MODIFIED)
+        serializer = CommissionListSerializer(commission, data=data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    def destroy(self, request):
+        if request.user.is_authenticated:
+            commission = get_object_or_404(Commission, pub_id__id=self.request.data['pub_id'],
+                                           user_id__id=request.data['user_id'])
+            self.perform_destroy(commission)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+


### PR DESCRIPTION
Endpoint per modificar i elimiar una comissió fet i unit tests també i passats.

url: 

api/catalog/user/commission/

se li ha de passar com a 'data' al post (substituint None per les modificacions):
data = {
            'user_id': user.id,
            'pub_id': pub.id,
            'description': None,
            'status': None
        }
se li ha de passar com a 'data' al delete:
data = {
            'user_id': user.id,
            'pub_id': pub.id
        }

