### PR TITLE
AR2-2 Crear metodo POST (autentificado) para añadir la publicación

### DIFF
--- a/usArt_backend/catalog/serializers.py
+++ b/usArt_backend/catalog/serializers.py
@@ -16,3 +16,9 @@ class PublicationListSerializer(serializers.ModelSerializer):
         model = Publication
         fields = ['id', 'title', 'description', 'author', 'price', 'images', 'type']
     
+class PublicationPostSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = Publication
+        fields = ['id', 'title', 'description', 'price', 'type']
+    

--- a/usArt_backend/catalog/serializers.py
+++ b/usArt_backend/catalog/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from catalog.models import Publication
+from catalog.models import Publication, PublicationImage
 from authentication.serializers import UsArtUserSerializer
 
 
@@ -17,8 +17,18 @@ class PublicationListSerializer(serializers.ModelSerializer):
         fields = ['id', 'title', 'description', 'author', 'price', 'images', 'type']
     
 class PublicationPostSerializer(serializers.ModelSerializer):
-    
     class Meta:
         model = Publication
-        fields = ['id', 'title', 'description', 'price', 'type']
-    
+        fields = ['title', 'description', 'price', 'type']
+
+    def create(self, validated_data):
+        publication = Publication.objects.create(
+            author=validated_data['author'],
+            title=validated_data['title'],
+            description=validated_data['description'],
+            price=validated_data['price'],
+            type=validated_data['type']
+        )
+        for image in validated_data['images']:
+            PublicationImage.objects.create(publication=publication, image=image)
+        return publication

--- a/usArt_backend/catalog/tests.py
+++ b/usArt_backend/catalog/tests.py
@@ -23,6 +23,7 @@ class TestPublicationModel(TestCase):
         self.assertEqual(publication.price, 5.0)
 
 
+
 class TestPublicationAPI(APITestCase):
     @classmethod
     def setUpTestData(cls):
@@ -55,7 +56,32 @@ class TestPublicationAPI(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_post_publication(self):
-        pass
+        url_post_login = reverse('api:token_obtain_pair')
+        login_data = {
+            'user_name': 'test',
+            'password': 'test'
+        }
+        response = self.client.post(url_post_login, login_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue('access' in response.data)
+        token = response.data['access']
+        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(token))
+
+        publication = {
+            'title' : 'publication',
+            'description' : 'description test',
+            'price' : 5.0,
+            'type' : 'CO'
+        }
+        url = reverse('catalog:post_publication')
+
+        response = self.client.post(url, publication, format='json')
+
+        dc = response.json()
+        self.assertEqual(dc['title'], 'publication',)
+        self.assertEqual(dc['description'], 'description test')
+        self.assertEqual(dc['type'], 'CO')
+        self.assertEqual(dc['price'], 5.0)
 
     def test_delete_publication(self):
         pass

--- a/usArt_backend/catalog/urls.py
+++ b/usArt_backend/catalog/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('', views.PublicationList.as_view(), name='publications_list'),
     path('<str:pk>', views.PublicationDetail.as_view(), name='publication_details'),
     path('user/<str:username>', views.PublicationUser.as_view(), name='publications_user'),
+    path('manage/post/', views.PublicationPosting.as_view(), name='post_publication')
 ]

--- a/usArt_backend/catalog/views.py
+++ b/usArt_backend/catalog/views.py
@@ -1,8 +1,10 @@
-from catalog.models import Publication
-from catalog.serializers import PublicationListSerializer
+from catalog.models import Publication, PublicationImage
+from catalog.serializers import PublicationListSerializer, PublicationPostSerializer
 
-from rest_framework import filters, generics
+from rest_framework import filters, generics, status
 import django_filters.rest_framework
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
 
 class PublicationList(generics.ListAPIView):
@@ -24,3 +26,21 @@ class PublicationUser(generics.ListAPIView):
 class PublicationDetail(generics.RetrieveAPIView):
     queryset = Publication.objects.all()
     serializer_class = PublicationListSerializer
+
+
+class PublicationPosting(generics.CreateAPIView):
+    permission_classes=[IsAuthenticated]
+    def post(self, request):
+        publication_serializer = PublicationPostSerializer(data=request.data)
+        if not publication_serializer.is_valid():
+            return Response(publication_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        res = Publication.objects.create(
+            author=request.user,
+            title=request.data['title'],
+            description=request.data['description'],
+            price=request.data['price'],
+            type=request.data['type']
+        )
+        for im in request.FILES.getlist('images'):
+            PublicationImage.objects.create(publication=res, image=im)
+        return Response(publication_serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
Creado el endpoint url:/api/catalog/manage/post/ para subir una publicación, hace falta estar autentificado y pasar por el body en form data:
* title: string del titulo
* description: string de la descripción
* price: float del precio
* type: choice del tipo  (AU, AR, CO)
* images: las imagenes subidas (de 1 a N)